### PR TITLE
Fix accessory view overlap swipe view

### DIFF
--- a/YMSwipeTableViewCell/PodFiles/UITableViewCell+Swipe.m
+++ b/YMSwipeTableViewCell/PodFiles/UITableViewCell+Swipe.m
@@ -301,8 +301,8 @@ static const void *YKTableSwipeContainerViewBackgroundColorKey = &YKTableSwipeCo
     CGPoint translation = [recognizer translationInView:recognizer.view];
 
     void (^initializeGestureRecognizerBeginningState)(void) = ^{
-        self.contentView.clipsToBounds = YES;
-        [self.contentView addSubview:self.swipeContainerView];
+        self.clipsToBounds = YES;
+        [self addSubview:self.swipeContainerView];
         self.swipeContainerView.layer.transform = CATransform3DIdentity;
         self.swipeContainerView.frame = self.bounds;
         [self.leftView removeFromSuperview];
@@ -328,7 +328,7 @@ static const void *YKTableSwipeContainerViewBackgroundColorKey = &YKTableSwipeCo
                 [self.swipeContainerView addSubview:self.leftView];
             }
         }
-        UIView *snapshotView = [self.contentView snapshotViewAfterScreenUpdates:NO];
+        UIView *snapshotView = [self snapshotViewAfterScreenUpdates:NO];
         [self setSwipeView:snapshotView];
         snapshotView.backgroundColor = self.backgroundColor;
         [self.swipeContainerView addSubview:self.swipeView];


### PR DESCRIPTION
Because `swipeViewContainer` is added into `self.contentView`, it will be overlaped by accessory view of the cell. Also `swipeView` is created from snapshot of `self.contentView` so it won't include the accessory view as well.