### PR TITLE
Fixed swipe cell being stuck in a semi-revealed state.

### DIFF
--- a/YMSwipeTableViewCell/PodFiles/UITableViewCell+Swipe.h
+++ b/YMSwipeTableViewCell/PodFiles/UITableViewCell+Swipe.h
@@ -14,6 +14,8 @@ static NSString * const YMSwipeGoToDefaultModeNotificationAnimationParameter = @
 typedef NS_ENUM(NSInteger, YATableSwipeMode) {
     /** The default cell state. The user has not begun swiping the cell. */
     YATableSwipeModeDefault,
+    /** The left or right swipe view is not completely exposed. The user is currently swiping. */
+    YATableSwipeModeSwiping,
     /** The left swipe view is completely exposed. The user has completed swiping from right to left. */
     YATableSwipeModeLeftON,
     /** The right swipe view is completely exposed. The user has completed swiping from left to right. */

--- a/YMSwipeTableViewCell/PodFiles/UITableViewCell+Swipe.m
+++ b/YMSwipeTableViewCell/PodFiles/UITableViewCell+Swipe.m
@@ -342,6 +342,8 @@ static const void *YKTableSwipeContainerViewBackgroundColorKey = &YKTableSwipeCo
         initializeGestureRecognizerBeginningState();
     }
     else if (recognizer.state == UIGestureRecognizerStateChanged) {
+        self.swipeMode = YATableSwipeModeSwiping;
+        
         // handle the case when velocity is 0 and no right or left views are created
         if (!([self.rightView isDescendantOfView:self.swipeContainerView] || [self.leftView isDescendantOfView:self.swipeContainerView])) {
             initializeGestureRecognizerBeginningState();
@@ -478,13 +480,13 @@ static const void *YKTableSwipeContainerViewBackgroundColorKey = &YKTableSwipeCo
         return YATableSwipeModeDefault;
     }
     if (velocity.x < 0) {
-        if (self.swipeMode == YATableSwipeModeDefault &&
+        if (self.swipeMode == YATableSwipeModeSwiping &&
             self.startDirection == YATableSwipeDirectionLeft) {
             return YATableSwipeModeRightON;
         }
     }
     else if (velocity.x > 0) {
-        if (self.swipeMode == YATableSwipeModeDefault &&
+        if (self.swipeMode == YATableSwipeModeSwiping &&
             self.startDirection == YATableSwipeDirectionRight) {
             return YATableSwipeModeLeftON;
         }


### PR DESCRIPTION
The bug:
If the pan gesture is failed or cancelled during swiping,`self.swipeMode` is still set to `YATableSwipeModeDefault` since the swipe is not fully complete. Then we reset cell to its default state using `[self goToDefaultMode:nil withAnimation:NO]`. But since `self.swipeMode` is `YATableSwipeModeDefault`, the` swipeView` will not transition to it's initial state. 

The fix:
Adding additional mode `YATableSwipeModeSwiping` to capture user swiping action.

@pwillsey 